### PR TITLE
Descriptions and default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ Options are always optional (duh). If an option is required, then it should be a
 ```php
 $app->command('greet firstname? lastname?', function () {
     // ...
-});
-$app->defaults('greet', [
+})->defaults([
     'firstname' => 'John',
     'lastname'  => 'Doe',
 ]);
@@ -86,8 +85,7 @@ $app->defaults('greet', [
 ```php
 $app->command('greet name --yell', function () {
     // ...
-});
-$app->descriptions('greet', 'Greet someone', [
+})->descriptions('Greet someone', [
     'name'   => 'Who do you want to greet?',
     '--yell' => 'If set, the task will yell in uppercase letters',
 ]);

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ A command can take options:
 
 Options are always optional (duh). If an option is required, then it should be an argument.
 
+#### Default values
+
+```php
+$app->command('greet firstname? lastname?', function () {
+    // ...
+});
+$app->defaults('greet', [
+    'firstname' => 'John',
+    'lastname'  => 'Doe',
+]);
+```
+
+#### Descriptions
+
+```php
+$app->command('greet name --yell', function () {
+    // ...
+});
+$app->descriptions('greet', 'Greet someone', [
+    'name'   => 'Who do you want to greet?',
+    '--yell' => 'If set, the task will yell in uppercase letters',
+]);
+```
+
 ### Command callable
 
 A command can be [any PHP callable](http://php.net/manual/en/language.types.callable.php):

--- a/src/Application.php
+++ b/src/Application.php
@@ -5,8 +5,11 @@ namespace Silly;
 use DI\Container;
 use DI\ContainerBuilder;
 use Silly\Command\ExpressionParser;
+use Silly\Input\InputArgument;
+use Silly\Input\InputOption;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -61,6 +64,32 @@ class Application extends SymfonyApplication
         $this->add($command);
     }
 
+    /**
+     * Define descriptions for the command and it's arguments/options.
+     *
+     * @param string $commandName                   Name of the command.
+     * @param string $description                   Description of the command.
+     * @param array  $argumentAndOptionDescriptions Descriptions of the arguments and options.
+     *
+     * @api
+     */
+    public function descriptions($commandName, $description, array $argumentAndOptionDescriptions = [])
+    {
+        $command = $this->get($commandName);
+        $commandDefinition = $command->getDefinition();
+
+        $command->setDescription($description);
+
+        foreach ($argumentAndOptionDescriptions as $name => $value) {
+            if (strpos($name, '--') === 0) {
+                $name = substr($name, 2);
+                $this->setOptionDescription($commandDefinition, $name, $value);
+            } else {
+                $this->setArgumentDescription($commandDefinition, $name, $value);
+            }
+        }
+    }
+
     private function createCommand($expression, callable $callable)
     {
         $result = $this->expressionParser->parse($expression);
@@ -72,5 +101,21 @@ class Application extends SymfonyApplication
         $command->setCode($callable);
 
         return $command;
+    }
+
+    private function setArgumentDescription(InputDefinition $definition, $name, $description)
+    {
+        $argument = $definition->getArgument($name);
+        if ($argument instanceof InputArgument) {
+            $argument->setDescription($description);
+        }
+    }
+
+    private function setOptionDescription(InputDefinition $definition, $name, $description)
+    {
+        $argument = $definition->getOption($name);
+        if ($argument instanceof InputOption) {
+            $argument->setDescription($description);
+        }
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -90,6 +90,25 @@ class Application extends SymfonyApplication
         }
     }
 
+    /**
+     * Define default values for the arguments of the command.
+     *
+     * @param string $commandName      Name of the command.
+     * @param array  $argumentDefaults Default argument values.
+     *
+     * @api
+     */
+    public function defaults($commandName, array $argumentDefaults = [])
+    {
+        $command = $this->get($commandName);
+        $commandDefinition = $command->getDefinition();
+
+        foreach ($argumentDefaults as $name => $default) {
+            $argument = $commandDefinition->getArgument($name);
+            $argument->setDefault($default);
+        }
+    }
+
     private function createCommand($expression, callable $callable)
     {
         $result = $this->expressionParser->parse($expression);

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,12 +4,9 @@ namespace Silly;
 
 use DI\Container;
 use DI\ContainerBuilder;
+use Silly\Command\Command;
 use Silly\Command\ExpressionParser;
-use Silly\Input\InputArgument;
-use Silly\Input\InputOption;
 use Symfony\Component\Console\Application as SymfonyApplication;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -43,6 +40,8 @@ class Application extends SymfonyApplication
      *
      * @param string   $expression Defines the arguments and options of the command.
      * @param callable $callable   Called when the command is called.
+     *
+     * @return Command
      */
     public function command($expression, callable $callable)
     {
@@ -62,51 +61,8 @@ class Application extends SymfonyApplication
         $command = $this->createCommand($expression, $commandFunction);
 
         $this->add($command);
-    }
 
-    /**
-     * Define descriptions for the command and it's arguments/options.
-     *
-     * @param string $commandName                   Name of the command.
-     * @param string $description                   Description of the command.
-     * @param array  $argumentAndOptionDescriptions Descriptions of the arguments and options.
-     *
-     * @api
-     */
-    public function descriptions($commandName, $description, array $argumentAndOptionDescriptions = [])
-    {
-        $command = $this->get($commandName);
-        $commandDefinition = $command->getDefinition();
-
-        $command->setDescription($description);
-
-        foreach ($argumentAndOptionDescriptions as $name => $value) {
-            if (strpos($name, '--') === 0) {
-                $name = substr($name, 2);
-                $this->setOptionDescription($commandDefinition, $name, $value);
-            } else {
-                $this->setArgumentDescription($commandDefinition, $name, $value);
-            }
-        }
-    }
-
-    /**
-     * Define default values for the arguments of the command.
-     *
-     * @param string $commandName      Name of the command.
-     * @param array  $argumentDefaults Default argument values.
-     *
-     * @api
-     */
-    public function defaults($commandName, array $argumentDefaults = [])
-    {
-        $command = $this->get($commandName);
-        $commandDefinition = $command->getDefinition();
-
-        foreach ($argumentDefaults as $name => $default) {
-            $argument = $commandDefinition->getArgument($name);
-            $argument->setDefault($default);
-        }
+        return $command;
     }
 
     private function createCommand($expression, callable $callable)
@@ -120,21 +76,5 @@ class Application extends SymfonyApplication
         $command->setCode($callable);
 
         return $command;
-    }
-
-    private function setArgumentDescription(InputDefinition $definition, $name, $description)
-    {
-        $argument = $definition->getArgument($name);
-        if ($argument instanceof InputArgument) {
-            $argument->setDescription($description);
-        }
-    }
-
-    private function setOptionDescription(InputDefinition $definition, $name, $description)
-    {
-        $argument = $definition->getOption($name);
-        if ($argument instanceof InputOption) {
-            $argument->setDescription($description);
-        }
     }
 }

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Silly\Command;
+
+use Silly\Input\InputArgument;
+use Silly\Input\InputOption;
+use Symfony\Component\Console\Input\InputDefinition;
+
+class Command extends \Symfony\Component\Console\Command\Command
+{
+    /**
+     * Define descriptions for the command and it's arguments/options.
+     *
+     * @param string $description                   Description of the command.
+     * @param array  $argumentAndOptionDescriptions Descriptions of the arguments and options.
+     *
+     * @api
+     */
+    public function descriptions($description, array $argumentAndOptionDescriptions = [])
+    {
+        $definition = $this->getDefinition();
+
+        $this->setDescription($description);
+
+        foreach ($argumentAndOptionDescriptions as $name => $value) {
+            if (strpos($name, '--') === 0) {
+                $name = substr($name, 2);
+                $this->setOptionDescription($definition, $name, $value);
+            } else {
+                $this->setArgumentDescription($definition, $name, $value);
+            }
+        }
+    }
+
+    /**
+     * Define default values for the arguments of the command.
+     *
+     * @param array $argumentDefaults Default argument values.
+     *
+     * @return $this
+     *
+     * @api
+     */
+    public function defaults(array $argumentDefaults = [])
+    {
+        $definition = $this->getDefinition();
+
+        foreach ($argumentDefaults as $name => $default) {
+            $argument = $definition->getArgument($name);
+            $argument->setDefault($default);
+        }
+
+        return $this;
+    }
+
+    private function setArgumentDescription(InputDefinition $definition, $name, $description)
+    {
+        $argument = $definition->getArgument($name);
+        if ($argument instanceof InputArgument) {
+            $argument->setDescription($description);
+        }
+    }
+
+    private function setOptionDescription(InputDefinition $definition, $name, $description)
+    {
+        $argument = $definition->getOption($name);
+        if ($argument instanceof InputOption) {
+            $argument->setDescription($description);
+        }
+    }
+}

--- a/src/Command/ExpressionParser.php
+++ b/src/Command/ExpressionParser.php
@@ -2,8 +2,8 @@
 
 namespace Silly\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
+use Silly\Input\InputArgument;
+use Silly\Input\InputOption;
 
 /**
  * Parses the expression that defines a command.

--- a/src/Input/InputArgument.php
+++ b/src/Input/InputArgument.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Silly\Input;
+
+/**
+ * Extending InputArgument because...
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class InputArgument extends \Symfony\Component\Console\Input\InputArgument
+{
+    private $description;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description ?: parent::getDescription();
+    }
+}

--- a/src/Input/InputOption.php
+++ b/src/Input/InputOption.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Silly\Input;
+
+/**
+ * Extending InputOption because...
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class InputOption extends \Symfony\Component\Console\Input\InputOption
+{
+    private $description;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description ?: parent::getDescription();
+    }
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Silly\Test;
+
+use Silly\Application;
+
+class ApplicationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function setUp()
+    {
+        $this->application = new Application();
+        $this->application->setAutoExit(false);
+        $this->application->setCatchExceptions(false);
+    }
+
+    /**
+     * @test
+     */
+    public function should_define_command_descriptions()
+    {
+        $this->application->command('greet name --yell', function () {});
+        $this->application->descriptions('greet', 'Greet someone', [
+            'name'   => 'Who?',
+            '--yell' => 'Yell?',
+        ]);
+
+        $command = $this->application->get('greet');
+
+        $this->assertEquals('Greet someone', $command->getDescription());
+        $this->assertEquals('Who?', $command->getDefinition()->getArgument('name')->getDescription());
+        $this->assertEquals('Yell?', $command->getDefinition()->getOption('yell')->getDescription());
+    }
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -3,6 +3,8 @@
 namespace Silly\Test;
 
 use Silly\Application;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,35 +23,12 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function allows_to_define_command_descriptions()
+    public function allows_to_define_commands()
     {
-        $this->application->command('greet name --yell', function () {});
-        $this->application->descriptions('greet', 'Greet someone', [
-            'name'   => 'Who?',
-            '--yell' => 'Yell?',
-        ]);
+        $command = $this->application->command('foo', function () {
+            return 1;
+        });
 
-        $command = $this->application->get('greet');
-
-        $this->assertEquals('Greet someone', $command->getDescription());
-        $this->assertEquals('Who?', $command->getDefinition()->getArgument('name')->getDescription());
-        $this->assertEquals('Yell?', $command->getDefinition()->getOption('yell')->getDescription());
-    }
-
-    /**
-     * @test
-     */
-    public function allows_to_define_default_values()
-    {
-        $this->application->command('greet firstname? lastname?', function () {});
-        $this->application->defaults('greet', [
-            'firstname' => 'John',
-            'lastname'  => 'Doe',
-        ]);
-
-        $definition = $this->application->get('greet')->getDefinition();
-
-        $this->assertEquals('John', $definition->getArgument('firstname')->getDefault());
-        $this->assertEquals('Doe', $definition->getArgument('lastname')->getDefault());
+        $this->assertSame($command, $this->application->get('foo'));
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -21,7 +21,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function should_define_command_descriptions()
+    public function allows_to_define_command_descriptions()
     {
         $this->application->command('greet name --yell', function () {});
         $this->application->descriptions('greet', 'Greet someone', [
@@ -34,5 +34,22 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Greet someone', $command->getDescription());
         $this->assertEquals('Who?', $command->getDefinition()->getArgument('name')->getDescription());
         $this->assertEquals('Yell?', $command->getDefinition()->getOption('yell')->getDescription());
+    }
+
+    /**
+     * @test
+     */
+    public function allows_to_define_default_values()
+    {
+        $this->application->command('greet firstname? lastname?', function () {});
+        $this->application->defaults('greet', [
+            'firstname' => 'John',
+            'lastname'  => 'Doe',
+        ]);
+
+        $definition = $this->application->get('greet')->getDefinition();
+
+        $this->assertEquals('John', $definition->getArgument('firstname')->getDefault());
+        $this->assertEquals('Doe', $definition->getArgument('lastname')->getDefault());
     }
 }

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Silly\Test;
+
+use Silly\Application;
+use Silly\Command\Command;
+
+class CommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    /**
+     * @var Command
+     */
+    private $command;
+
+    public function setUp()
+    {
+        $this->application = new Application();
+        $this->application->setAutoExit(false);
+        $this->application->setCatchExceptions(false);
+
+        $this->command = $this->application->command('greet name? --yell', function () {});
+    }
+
+    /**
+     * @test
+     */
+    public function allows_to_define_descriptions()
+    {
+        $this->command->descriptions('Greet someone', [
+            'name'   => 'Who?',
+            '--yell' => 'Yell?',
+        ]);
+
+        $definition = $this->command->getDefinition();
+
+        $this->assertEquals('Greet someone', $this->command->getDescription());
+        $this->assertEquals('Who?', $definition->getArgument('name')->getDescription());
+        $this->assertEquals('Yell?', $definition->getOption('yell')->getDescription());
+    }
+
+    /**
+     * @test
+     */
+    public function allows_to_define_default_values()
+    {
+        $this->command->defaults([
+            'name' => 'John',
+        ]);
+
+        $definition = $this->command->getDefinition();
+
+        $this->assertEquals('John', $definition->getArgument('name')->getDefault());
+    }
+}

--- a/tests/Command/ExpressionParserTest.php
+++ b/tests/Command/ExpressionParserTest.php
@@ -3,8 +3,8 @@
 namespace Silly\Test\Command;
 
 use Silly\Command\ExpressionParser;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
+use Silly\Input\InputArgument;
+use Silly\Input\InputOption;
 
 class ExpressionParserTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This PR brings support to set descriptions and default values:

``` php
$app->command('greet firstname? lastname?', function () {
    // ...
});

$app->defaults('greet', [
    'firstname' => 'John',
    'lastname'  => 'Doe',
]);

$app->descriptions('greet', 'Greet someone', [
    'name'   => 'Who do you want to greet?',
    '--yell' => 'If set, the task will yell in uppercase letters',
]);
```
