### PR TITLE
Dependency injection and containers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.5",
         "symfony/console": "~2.6",
-        "mnapoli/invoker": "~0.2.0",
+        "mnapoli/invoker": "~0.2.1",
         "container-interop/container-interop": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,11 @@
     "require": {
         "php": ">=5.5",
         "symfony/console": "~2.6",
-        "mnapoli/invoker": "~0.2.0"
+        "mnapoli/invoker": "~0.2.0",
+        "container-interop/container-interop": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "~4.5",
+        "mnapoli/phpunit-easymock": "~0.1.0"
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -2,9 +2,9 @@
 
 namespace Silly\Test;
 
+use EasyMock\EasyMock;
+use Invoker\InvokerInterface;
 use Silly\Application;
-use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\NullOutput;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
 {
@@ -30,5 +30,18 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertSame($command, $this->application->get('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function allows_to_set_an_invoker()
+    {
+        /** @var InvokerInterface $invoker */
+        $invoker = EasyMock::mock(InvokerInterface::class);
+
+        $this->application->setInvoker($invoker);
+
+        $this->assertSame($invoker, $this->application->getInvoker());
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -5,6 +5,7 @@ namespace Silly\Test;
 use Silly\Application;
 use Silly\Test\Fixture\SpyOutput;
 use Silly\Test\Mock\ArrayContainer;
+use stdClass;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface as Out;
 
@@ -99,7 +100,7 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_should_resolve_a_callable_string_from_a_container()
+    public function it_can_resolve_a_callable_string_from_a_container()
     {
         $container = new ArrayContainer([
             'command.greet' => function (Out $output) {
@@ -116,7 +117,7 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_should_resolve_a_callable_array_from_a_container()
+    public function it_can_resolve_a_callable_array_from_a_container()
     {
         $container = new ArrayContainer([
             // Calls $this->foo()
@@ -127,6 +128,106 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $this->application->command('greet', 'command.greet');
 
         $this->assertOutputIs('greet', 'hello');
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_inject_using_type_hints()
+    {
+        $stdClass = new stdClass();
+        $stdClass->foo = 'hello';
+        $container = new ArrayContainer([
+            'stdClass' => $stdClass,
+        ]);
+        $this->application->useContainer($container, true);
+
+        $this->application->command('greet', function (Out $output, stdClass $param) {
+            $output->write($param->foo);
+        });
+
+        $this->assertOutputIs('greet', 'hello');
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_inject_using_parameter_names()
+    {
+        $stdClass = new stdClass();
+        $stdClass->foo = 'hello';
+        $container = new ArrayContainer([
+            'param' => $stdClass,
+        ]);
+        $this->application->useContainer($container, false, true);
+
+        $this->application->command('greet', function (Out $output, $param) {
+            $output->write($param->foo);
+        });
+
+        $this->assertOutputIs('greet', 'hello');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_inject_command_parameters_in_priority_over_dependency_injection()
+    {
+        $container = new ArrayContainer([
+            'param' => 'bob',
+        ]);
+        $this->application->useContainer($container, false, true);
+
+        $this->application->command('greet param', function (Out $output, $param) {
+            $output->write($param);
+        });
+
+        $this->assertOutputIs('greet john', 'john');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_inject_using_type_hint_in_priority_if_both_are_configured()
+    {
+        $stdClass1 = new stdClass();
+        $stdClass1->foo = 'hello';
+        $stdClass2 = new stdClass();
+        $stdClass2->foo = 'nope!';
+        $container = new ArrayContainer([
+            'stdClass' => $stdClass1,
+            'param'    => $stdClass2,
+        ]);
+        // Configured to inject both with type-hints and parameter names
+        $this->application->useContainer($container, true, true);
+
+        $this->application->command('greet', function (Out $output, stdClass $param) {
+            $output->write($param->foo);
+        });
+
+        $this->assertOutputIs('greet', 'hello');
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Impossible to call the 'greet' command: Unable to invoke the callable because no value was given for parameter 1 ($foo)
+     */
+    public function it_should_throw_if_a_parameter_cannot_be_resolved()
+    {
+        $this->application->command('greet', function (stdClass $foo) {});
+        $this->assertOutputIs('greet', '');
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Impossible to call the 'greet' command: 'foo' is not a callable
+     */
+    public function it_should_throw_if_the_command_is_not_a_callable()
+    {
+        $this->application->command('greet', 'foo');
+        $this->assertOutputIs('greet', '');
     }
 
     private function assertOutputIs($command, $expected)

--- a/tests/Mock/ArrayContainer.php
+++ b/tests/Mock/ArrayContainer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Silly\Test\Mock;
+
+use Interop\Container\ContainerInterface;
+
+class ArrayContainer implements ContainerInterface
+{
+    private $entries = [];
+
+    public function __construct(array $entries = [])
+    {
+        $this->entries = $entries;
+    }
+
+    public function get($id)
+    {
+        return $this->entries[$id];
+    }
+
+    public function has($id)
+    {
+        return isset($this->entries[$id]);
+    }
+}


### PR DESCRIPTION
This pull request introduces the ability for Silly to work with any DI container thanks to [container-interop](https://github.com/container-interop/container-interop) and [Invoker](https://github.com/mnapoli/Invoker).

TODO:
- [x] documentation
### Set up a container

You can set up any container-interop compliant container, or use [Acclimate](https://github.com/jeremeamia/acclimate-container) if not.

``` php
$application->useContainer($container);
```
### Resolve callables from a container

You can store commands in your container now:

``` php
$container->set('command.greet', function ($output) {
    $output->write('hello');
});

$application->useContainer($container);
$application->command('greet [name]', 'command.greet');
```

That allows to write commands as classes, for example:

``` php
// ...

// will get GreetCommand from the container and call GreetCommand::execute()
$application->command('greet [name]', [GreetCommand::class, 'execute']);
```

This makes it quite nice for scaling an application from quick and dirty in one file with closures to decoupled and organized into classes and namespaces…

_Only commands that are not PHP callables will be fetched from the container. Commands that are PHP callables are not affected (which is what we want)._
### Dependency injection in callables

The feature above let you create your commands using your container. But you can also do dependency injection in the callable parameters, like in AngularJS:

``` php
// See below for the explanation of these arguments
$application->useContainer($container, $injectByTypeHint, $injectByParameterName);

$application->command('greet', function (Psr\Log\LoggerInterface $logger) {
    $logger->info('I am greeting');
});
```
- set `$injectByTypeHint` to `true` to make Silly fetch container entries by their type-hint, i.e. call `$container->get('Psr\Log\LoggerInterface')`
- set `$injectByParameterName` to `true` to make Silly fetch container entries by the parameter name, i.e. call `$container->get('logger')`

By default both are disabled: **this feature is optional**.

If you set both to `true`, it will first look using the type-hint, then using the parameter name.

In case of conflict with a command parameters, the command parameter is injected in priority over dependency injection.
