### PR TITLE
Use __invoke() instead of execute()

### DIFF
--- a/docs/php-di.md
+++ b/docs/php-di.md
@@ -18,9 +18,11 @@ $ composer require mnapoli/silly-php-di
 Thanks to PHP-DI's autowiring capabilities you can define your commands in classes:
 
 ```php
+use Symfony\Component\Console\Output\OutputInterface;
+
 class MyCommand
 {
-    public function execute($name, OutputInterface $output)
+    public function __invoke($name, OutputInterface $output)
     {
         if ($name) {
             $text = 'Hello, '.$name;


### PR DESCRIPTION
Otherwise the PHP-DI\Invoker will throw the exception:

```
[RuntimeException]                                                                                   
  Impossible to call the 'greet' command: Instance of MyCommand is not a callable
```
