### PR TITLE
Make the descriptions setter fluent

### DIFF
--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -14,6 +14,8 @@ class Command extends \Symfony\Component\Console\Command\Command
      * @param string $description                   Description of the command.
      * @param array  $argumentAndOptionDescriptions Descriptions of the arguments and options.
      *
+     * @return $this
+     *
      * @api
      */
     public function descriptions($description, array $argumentAndOptionDescriptions = [])
@@ -30,6 +32,8 @@ class Command extends \Symfony\Component\Console\Command\Command
                 $this->setArgumentDescription($definition, $name, $value);
             }
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Allow descriptions and default values definition to be chained, like in the following example:

``` php
$app->command('greet [firstname] [lastname]', function () {
    // ...
})->descriptions('Greet someone')->defaults([
    'firstname' => 'John',
    'lastname'  => 'Doe',
]);
```
