### PR TITLE
Allow options to have default parameters

### DIFF
--- a/docs/command-definition.md
+++ b/docs/command-definition.md
@@ -42,7 +42,7 @@ $app->command('greet [firstname] [lastname] [--age=]', function () {
 })->defaults([
     'firstname' => 'John',
     'lastname'  => 'Doe',
-    '--age' => 25,
+    'age' => 25,
 ]);
 ```
 

--- a/docs/command-definition.md
+++ b/docs/command-definition.md
@@ -37,11 +37,12 @@ Options are always optional (duh). If an option is required, then it should be a
 ## Default values
 
 ```php
-$app->command('greet [firstname] [lastname]', function () {
+$app->command('greet [firstname] [lastname] [--age=]', function () {
     // ...
 })->defaults([
     'firstname' => 'John',
     'lastname'  => 'Doe',
+    '--age' => 25,
 ]);
 ```
 

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -52,13 +52,15 @@ class Command extends \Symfony\Component\Console\Command\Command
         foreach ($defaults as $name => $default) {
             if ($definition->hasArgument($name)) {
                 $input = $definition->getArgument($name);
-            } else if ($definition->hasOption($name)) {
+            } elseif ($definition->hasOption($name)) {
                 $input = $definition->getOption($name);
-            } else if (strpos($name, '--') === 0) {
+            } elseif (strpos($name, '--') === 0) {
                 $name = substr($name, 2);
                 $input = $definition->getOption($name);
             } else {
-                throw new \InvalidArgumentException("Unable to set default for [{$name}]. It does not exist as an argument or option.");
+                throw new \InvalidArgumentException(
+                    "Unable to set default for [{$name}]. It does not exist as an argument or option."
+                );
             }
 
             $input->setDefault($default);

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -45,13 +45,19 @@ class Command extends \Symfony\Component\Console\Command\Command
      *
      * @api
      */
-    public function defaults(array $argumentDefaults = [])
+    public function defaults(array $defaults = [])
     {
         $definition = $this->getDefinition();
 
-        foreach ($argumentDefaults as $name => $default) {
-            $argument = $definition->getArgument($name);
-            $argument->setDefault($default);
+        foreach ($defaults as $name => $default) {
+            if (strpos($name, '--') === 0) {
+                $name = substr($name, 2);
+                $input = $definition->getOption($name);
+            } else {
+                $input = $definition->getArgument($name);
+            }
+
+            $input->setDefault($default);
         }
 
         return $this;

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -39,7 +39,7 @@ class Command extends \Symfony\Component\Console\Command\Command
     /**
      * Define default values for the arguments of the command.
      *
-     * @param array $argumentDefaults Default argument values.
+     * @param array $defaults Default argument values.
      *
      * @return $this
      *

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -54,9 +54,6 @@ class Command extends \Symfony\Component\Console\Command\Command
                 $input = $definition->getArgument($name);
             } elseif ($definition->hasOption($name)) {
                 $input = $definition->getOption($name);
-            } elseif (strpos($name, '--') === 0) {
-                $name = substr($name, 2);
-                $input = $definition->getOption($name);
             } else {
                 throw new \InvalidArgumentException(
                     "Unable to set default for [{$name}]. It does not exist as an argument or option."

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -50,11 +50,15 @@ class Command extends \Symfony\Component\Console\Command\Command
         $definition = $this->getDefinition();
 
         foreach ($defaults as $name => $default) {
-            if (strpos($name, '--') === 0) {
+            if ($definition->hasArgument($name)) {
+                $input = $definition->getArgument($name);
+            } else if ($definition->hasOption($name)) {
+                $input = $definition->getOption($name);
+            } else if (strpos($name, '--') === 0) {
                 $name = substr($name, 2);
                 $input = $definition->getOption($name);
             } else {
-                $input = $definition->getArgument($name);
+                throw new \InvalidArgumentException("Unable to set default for [{$name}]. It does not exist as an argument or option.");
             }
 
             $input->setDefault($default);

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -23,7 +23,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->application->setAutoExit(false);
         $this->application->setCatchExceptions(false);
 
-        $this->command = $this->application->command('greet [name] [--yell]', function () {});
+        $this->command = $this->application->command('greet [name] [--yell] [--times=]', function () {});
     }
 
     /**
@@ -34,6 +34,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->command->descriptions('Greet someone', [
             'name'   => 'Who?',
             '--yell' => 'Yell?',
+            '--times' => '# of times to greet?',
         ]);
 
         $definition = $this->command->getDefinition();
@@ -41,6 +42,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Greet someone', $this->command->getDescription());
         $this->assertEquals('Who?', $definition->getArgument('name')->getDescription());
         $this->assertEquals('Yell?', $definition->getOption('yell')->getDescription());
+        $this->assertEquals('# of times to greet?', $definition->getOption('times')->getDescription());
     }
 
     /**
@@ -50,10 +52,12 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         $this->command->defaults([
             'name' => 'John',
+            '--times' => '1',
         ]);
 
         $definition = $this->command->getDefinition();
 
         $this->assertEquals('John', $definition->getArgument('name')->getDefault());
+        $this->assertEquals('1', $definition->getOption('times')->getDefault());
     }
 }

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -64,6 +64,20 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function allows_default_values_to_be_inferred_from_closure_parameters()
+    {
+        $command = $this->application->command('greet [name] [--yell] [--times=]', function ($times = 15) {
+            //
+        });
+
+        $definition = $command->getDefinition();
+
+        $this->assertEquals(15, $definition->getOption("times")->getDefault());
+    }
+
+    /**
+     * @test
+     */
     public function setting_defaults_falls_back_to_options_when_no_argument_exists()
     {
         $this->command->defaults([

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -52,7 +52,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         $this->command->defaults([
             'name' => 'John',
-            '--times' => '1',
+            'times' => '1',
         ]);
 
         $definition = $this->command->getDefinition();

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -60,4 +60,29 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('John', $definition->getArgument('name')->getDefault());
         $this->assertEquals('1', $definition->getOption('times')->getDefault());
     }
+
+    /**
+     * @test
+     */
+    public function setting_defaults_falls_back_to_options_when_no_argument_exists()
+    {
+        $this->command->defaults([
+            'times' => '5',
+        ]);
+
+        $definition = $this->command->getDefinition();
+
+        $this->assertEquals(5, $definition->getOption("times")->getDefault());
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function setting_unknown_defaults_throws_an_exception()
+    {
+        $this->command->defaults([
+            'doesnotexist' => '0',
+        ]);
+    }
 }


### PR DESCRIPTION
I saw #21 after I ran into a need for this today.
- Default parameters will now also be determined via reflection.
- Setting defaults via `->defaults(…)` will now set defaults for matching options as well.
