### PR TITLE
Match inputs containing hyphens against parameter names

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -45,6 +45,10 @@ class Application extends SymfonyApplication
         $this->expressionParser = new ExpressionParser();
         $this->invoker = new Invoker();
 
+        if ($this->invoker->getParameterResolver() instanceof ResolverChain) {
+            $this->invoker->getParameterResolver()->appendResolver(new HyphenatedInputResolver);
+        }
+
         parent::__construct($name, $version);
     }
 
@@ -132,6 +136,7 @@ class Application extends SymfonyApplication
 
         $resolvers = [
             new AssociativeArrayResolver,
+            new HyphenatedInputResolver,
         ];
         if ($injectByTypeHint) {
             $resolvers[] = new TypeHintContainerResolver($container);

--- a/src/Application.php
+++ b/src/Application.php
@@ -9,6 +9,8 @@ use Invoker\InvokerInterface;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
 use Invoker\ParameterResolver\Container\ParameterNameContainerResolver;
 use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
+use Invoker\ParameterResolver\DefaultValueResolver;
+use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ResolverChain;
 use Silly\Command\Command;
 use Silly\Command\ExpressionParser;
@@ -43,11 +45,7 @@ class Application extends SymfonyApplication
     public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
     {
         $this->expressionParser = new ExpressionParser();
-        $this->invoker = new Invoker();
-
-        if ($this->invoker->getParameterResolver() instanceof ResolverChain) {
-            $this->invoker->getParameterResolver()->appendResolver(new HyphenatedInputResolver);
-        }
+        $this->invoker = new Invoker($this->createParameterResolver());
 
         parent::__construct($name, $version);
     }
@@ -199,5 +197,20 @@ class Application extends SymfonyApplication
         $command->setCode($callable);
 
         return $command;
+    }
+
+    /**
+     * Create the default parameter resolver.
+     *
+     * @return ParameterResolver
+     */
+    private function createParameterResolver()
+    {
+        return new ResolverChain([
+            new NumericArrayResolver,
+            new AssociativeArrayResolver,
+            new HyphenatedInputResolver,
+            new DefaultValueResolver,
+        ]);
     }
 }

--- a/src/HyphenatedInputResolver.php
+++ b/src/HyphenatedInputResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Silly;
+
+use ReflectionFunctionAbstract;
+use Invoker\ParameterResolver\ParameterResolver;
+
+/**
+ * Tries to maps hyphenated parameters to a similarly-named,
+ * non-hyphenated parameters in the function signature.
+ *
+ * E.g. `->call($callable, ['dry-run' => true])` will inject the boolean `true`
+ * for a parameter named either `$dryrun` or `$dryRun`.
+ *
+ */
+class HyphenatedInputResolver implements ParameterResolver
+{
+    public function getParameters(
+        ReflectionFunctionAbstract $reflection,
+        array $providedParameters,
+        array $resolvedParameters
+    ) {
+        $parameters = [];
+
+        foreach ($reflection->getParameters() as $index => $parameter) {
+            $parameters[strtolower($parameter->name)] = $index;
+        }
+
+        foreach ($providedParameters as $name => $value) {
+            $normalizedName = strtolower(str_replace("-", "", $name));
+
+            // Skip parameters that do not exist with the normalized name
+            if (! array_key_exists($normalizedName, $parameters)) {
+                continue;
+            }
+
+            $normalizedParameterIndex = $parameters[$normalizedName];
+
+            // Skip parameters already resolved
+            if (array_key_exists($normalizedParameterIndex, $resolvedParameters)) {
+                continue;
+            }
+
+            $resolvedParameters[$normalizedParameterIndex] = $value;
+        }
+
+        return $resolvedParameters;
+    }
+}

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -112,6 +112,52 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_should_match_hyphenated_arguments_to_lowercase_parameters()
+    {
+        $this->application->command('greet first-name', function ($firstname, Out $output) {
+            $output->write('hello ' . $firstname);
+        });
+        $this->assertOutputIs('greet john', 'hello john');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_match_hyphenated_arguments_to_mixedcase_parameters()
+    {
+        $this->application->command('greet first-name', function ($firstName, Out $output) {
+            $output->write('hello ' . $firstName);
+        });
+        $this->assertOutputIs('greet john', 'hello john');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_match_hyphenated_option_to_lowercase_parameters()
+    {
+        $this->application->command('greet [--yell-louder]', function ($yelllouder, Out $output) {
+            $output->write(var_export($yelllouder, true));
+        });
+        $this->assertOutputIs('greet', 'false');
+        $this->assertOutputIs('greet --yell-louder', 'true');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_match_hyphenated_option_to_mixed_case_parameters()
+    {
+        $this->application->command('greet [--yell-louder]', function ($yellLouder, Out $output) {
+            $output->write(var_export($yellLouder, true));
+        });
+        $this->assertOutputIs('greet', 'false');
+        $this->assertOutputIs('greet --yell-louder', 'true');
+    }
+
+    /**
+     * @test
+     */
     public function it_can_resolve_a_callable_string_from_a_container()
     {
         $container = new ArrayContainer([


### PR DESCRIPTION
Currently, it is not possible specify a argument or option name with a hyphen in it (e.g. `--dry-run`) and have that match a parameter name in the callable like `$dryRun`.

This is unfortunate because multi-word options are a quite common occurrence in tools.
e.x. the version of rsync I have installed has 57 (!) multi-word options and 39 of those are _not_ aliased.

Also, in some cases (like `--dry-run`) the wording used is quite common so that's what would be reached for first.

I took some time to create a resolver that will un-hyphenate and lowercase the names before matching against closure parameters to solve this issue.
