### PR TITLE
Fix a few bugs

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -93,9 +93,7 @@ class Application extends SymfonyApplication
         $command = $this->createCommand($expression, $commandFunction);
         $command->setAliases($aliases);
 
-        if (is_callable($callable)) {
-            $command->defaults($this->defaultsViaReflection($command, $callable));
-        }
+        $command->defaults($this->defaultsViaReflection($command, $callable));
 
         $this->add($command);
 
@@ -206,6 +204,10 @@ class Application extends SymfonyApplication
 
     private function defaultsViaReflection($command, $callable)
     {
+        if (! is_callable($callable)) {
+            return [];
+        }
+
         $function = CallableReflection::create($callable);
 
         $definition = $command->getDefinition();

--- a/src/Application.php
+++ b/src/Application.php
@@ -94,7 +94,7 @@ class Application extends SymfonyApplication
         $command->setAliases($aliases);
 
         if (is_callable($callable)) {
-            $command->defaults($this->defaultsViaReflection($callable));
+            $command->defaults($this->defaultsViaReflection($command, $callable));
         }
 
         $this->add($command);
@@ -204,14 +204,20 @@ class Application extends SymfonyApplication
         return $command;
     }
 
-    private function defaultsViaReflection(callable $callable)
+    private function defaultsViaReflection($command, $callable)
     {
         $function = new ReflectionFunction($callable);
+
+        $definition = $command->getDefinition();
 
         $defaults = [];
 
         foreach ($function->getParameters() as $parameter) {
             if (! $parameter->isDefaultValueAvailable()) {
+                continue;
+            }
+
+            if (! $definition->hasArgument($parameter->name) && ! $definition->hasOption($parameter->name)) {
                 continue;
             }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,6 +13,7 @@ use Invoker\ParameterResolver\DefaultValueResolver;
 use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ResolverChain;
 use ReflectionFunction;
+use ReflectionMethod;
 use Silly\Command\Command;
 use Silly\Command\ExpressionParser;
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -204,9 +205,18 @@ class Application extends SymfonyApplication
         return $command;
     }
 
-    private function defaultsViaReflection($command, $callable)
+    private function reflect($callable)
     {
-        $function = new ReflectionFunction($callable);
+        if (is_array($callable)) {
+            return new ReflectionMethod($callable[0], $callable[1]);
+        }
+
+        return new ReflectionFunction($callable);
+    }
+
+    private function defaultsViaReflection($command, callable $callable)
+    {
+        $function = $this->reflect($callable);
 
         $definition = $command->getDefinition();
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -214,7 +214,7 @@ class Application extends SymfonyApplication
         return new ReflectionFunction($callable);
     }
 
-    private function defaultsViaReflection($command, callable $callable)
+    private function defaultsViaReflection($command, $callable)
     {
         $function = $this->reflect($callable);
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -12,8 +12,7 @@ use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
 use Invoker\ParameterResolver\DefaultValueResolver;
 use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ResolverChain;
-use ReflectionFunction;
-use ReflectionMethod;
+use Invoker\Reflection\CallableReflection;
 use Silly\Command\Command;
 use Silly\Command\ExpressionParser;
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -205,18 +204,9 @@ class Application extends SymfonyApplication
         return $command;
     }
 
-    private function reflect($callable)
-    {
-        if (is_array($callable)) {
-            return new ReflectionMethod($callable[0], $callable[1]);
-        }
-
-        return new ReflectionFunction($callable);
-    }
-
     private function defaultsViaReflection($command, $callable)
     {
-        $function = $this->reflect($callable);
+        $function = CallableReflection::create($callable);
 
         $definition = $command->getDefinition();
 

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -99,4 +99,20 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             'doesnotexist' => '0',
         ]);
     }
+
+    /**
+     * @test
+     */
+    public function arguments_that_do_not_map_to_defaults_are_not_added()
+    {
+        $this->application->command('greet [name]', [new GreetCommand, 'greet']);
+    }
+}
+
+class GreetCommand
+{
+    public function greet($times = 15)
+    {
+        //
+    }
 }

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -119,6 +119,14 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         $this->application->command('greet [name]', [new GreetCommand, 'greet']);
     }
+
+    /**
+     * @test
+     */
+    public function a_command_with_an_invalid_static_callable_should_not_throw_deprecation_notices()
+    {
+        $this->application->command('greet [name]', [GreetCommand::class, 'greet']);
+    }
 }
 
 class GreetCommand

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -78,6 +78,18 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function allows_default_values_to_be_inferred_from_callble_parameters()
+    {
+        $command = $this->application->command('greet [name] [--yell] [--times=]', [new GreetCommand, "greet"]);
+
+        $definition = $command->getDefinition();
+
+        $this->assertEquals(15, $definition->getOption("times")->getDefault());
+    }
+
+    /**
+     * @test
+     */
     public function setting_defaults_falls_back_to_options_when_no_argument_exists()
     {
         $this->command->defaults([

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -115,9 +115,11 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function arguments_that_do_not_map_to_defaults_are_not_added()
+    public function reflecting_defaults_for_nonexistant_inputs_does_not_throw_an_exception()
     {
         $this->application->command('greet [name]', [new GreetCommand, 'greet']);
+
+        // An exception was thrown previously about the argument / option `times` not existing.
     }
 
     /**

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -124,8 +124,9 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @expectedException InvalidArgumentException
      */
-    public function a_command_with_an_invalid_static_callable_should_not_throw_deprecation_notices()
+    public function a_command_with_an_invalid_static_callable_show_throw_an_exception()
     {
         $this->application->command('greet [name]', [GreetCommand::class, 'greet']);
     }


### PR DESCRIPTION
- Don't attempt to reflect and set defaults for inputs that do not exist.
- Infer defaults for any valid callable.
- Fix issue #27. Explanation detailed in commit. But essentially: `is_callable` and `callable` disagree with one another causing php to issue a deprecation notice.
