### PR TITLE
private -> protected accessibility for overloading

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -31,17 +31,17 @@ class Application extends SymfonyApplication
     /**
      * @var ExpressionParser
      */
-    private $expressionParser;
+    protected $expressionParser;
 
     /**
      * @var InvokerInterface
      */
-    private $invoker;
+    protected $invoker;
 
     /**
      * @var ContainerInterface|null
      */
-    private $container;
+    protected $container;
 
     public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
     {
@@ -191,7 +191,7 @@ class Application extends SymfonyApplication
         $this->invoker = $invoker;
     }
 
-    private function createCommand($expression, callable $callable)
+    protected function createCommand($expression, callable $callable)
     {
         $result = $this->expressionParser->parse($expression);
 
@@ -204,7 +204,7 @@ class Application extends SymfonyApplication
         return $command;
     }
 
-    private function assertCallableIsValid($callable)
+    protected function assertCallableIsValid($callable)
     {
         if ($this->container) {
             return;
@@ -220,7 +220,7 @@ class Application extends SymfonyApplication
         }
     }
 
-    private function defaultsViaReflection($command, $callable)
+    protected function defaultsViaReflection($command, $callable)
     {
         if (! is_callable($callable)) {
             return [];
@@ -252,7 +252,7 @@ class Application extends SymfonyApplication
      *
      * @return ParameterResolver
      */
-    private function createParameterResolver()
+    protected function createParameterResolver()
     {
         return new ResolverChain([
             new NumericArrayResolver,
@@ -268,7 +268,7 @@ class Application extends SymfonyApplication
      * @param mixed $callable
      * @return bool
      */
-    private function isStaticCallToNonStaticMethod($callable)
+    protected function isStaticCallToNonStaticMethod($callable)
     {
         if (is_array($callable) && is_string($callable[0])) {
             list($class, $method) = $callable;

--- a/src/Command/ExpressionParser.php
+++ b/src/Command/ExpressionParser.php
@@ -46,12 +46,12 @@ class ExpressionParser
         ];
     }
 
-    private function isOption($token)
+    protected function isOption($token)
     {
         return $this->startsWith($token, '[-');
     }
 
-    private function parseArgument($token)
+    protected function parseArgument($token)
     {
         if ($this->endsWith($token, ']*')) {
             $mode = InputArgument::IS_ARRAY;
@@ -70,7 +70,7 @@ class ExpressionParser
         return new InputArgument($name, $mode);
     }
 
-    private function parseOption($token)
+    protected function parseOption($token)
     {
         $token = trim($token, '[]');
 
@@ -97,12 +97,12 @@ class ExpressionParser
         return new InputOption($name, $shortcut, $mode);
     }
 
-    private function startsWith($haystack, $needle)
+    protected function startsWith($haystack, $needle)
     {
         return substr($haystack, 0, strlen($needle)) === $needle;
     }
 
-    private function endsWith($haystack, $needle)
+    protected function endsWith($haystack, $needle)
     {
         return substr($haystack, -strlen($needle)) === $needle;
     }


### PR DESCRIPTION
In order to develop _Single command_ applications it is required to use the _defaultCommand_. To do we need to overload the `ExpressionParser`. In the method _parse_ we need to disable the line:

``` php
$name = array_shift($tokens);
```

and later passing of the name:

``` php
        return [
        //    'name' => $name,
            'arguments' => $arguments,
            'options' => $options,
        ];
```

There would be no problem in that, but since methods like `parseOption`, `startsWith` (etc.) are private it is required to repeat them in the child class. Having them protected would allow use of inheritance:

``` php
class SingleCommandExpressionParser extends ExpressionParser
```

Going further, we need to update the method `createCommand`, but we also need to overload `command` as it calls `createCommand` of the parent scope if not overloaded. If overloaded then we need to repeat `assertCallableIsValid` (etc.) again to be accessible.
