### PR TITLE
#36 Enable injecting the `SymfonyStyle` object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "symfony/console": "~2.6|~3.0",
+        "symfony/console": "~2.8|~3.0",
         "php-di/invoker": "~1.2",
         "container-interop/container-interop": "~1.0"
     },

--- a/docs/command-callables.md
+++ b/docs/command-callables.md
@@ -57,6 +57,18 @@ $app->command(
 );
 ```
 
+You can also inject the `SymfonyStyle` object by type-hinting it:
+
+```php
+use \Symfony\Component\Console\Style\SymfonyStyle;
+
+...
+
+$app->command('greet', function (SymfonyStyle $io) {
+    $io->write('hello');
+});
+```
+
 Finally, you can mix all that (remember the order of parameters doesn't matter):
 
 ```php

--- a/src/Application.php
+++ b/src/Application.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * CLI application.
@@ -79,6 +80,7 @@ class Application extends SymfonyApplication
                     OutputInterface::class => $output,
                     Input::class => $input,
                     Output::class => $output,
+                    SymfonyStyle::class => new SymfonyStyle($input, $output),
                 ],
                 // Arguments and options are injected by parameter names
                 $input->getArguments(),

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface as Out;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class FunctionalTest extends \PHPUnit_Framework_TestCase
 {
@@ -112,6 +113,17 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
             $out->write('hello ' . $in->getArgument('name'));
         });
         $this->assertOutputIs('greet john', 'hello john');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_inject_the_symfony_style_object()
+    {
+        $this->application->command('greet', function (SymfonyStyle $io) {
+            $io->write('hello');
+        });
+        $this->assertOutputIs('greet', 'hello');
     }
 
     /**


### PR DESCRIPTION
Fix #36

Example:

```php
use \Symfony\Component\Console\Style\SymfonyStyle;

...

$app->command('greet', function (SymfonyStyle $io) {
    $io->write('hello');
});
```