### PR TITLE
Migrate to PSR-11 and PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
-sudo: false
+matrix:
+  include:
+    - php: 7.0
+      env: dependencies=lowest
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 before_script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
-  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer install -n ; fi
+  - composer install -n
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 
 script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
-  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then vendor/bin/phpunit ; fi
-
-after_script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then php vendor/bin/coveralls -v ; fi
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mnapoli/silly",
     "description": "Silly CLI micro-framework based on Symfony Console",
-    "keywords": ["cli", "console", "framework", "micro-framework", "silly"],
+    "keywords": ["cli", "console", "framework", "micro-framework", "silly", "psr-11"],
     "license": "MIT",
     "type": "library",
     "autoload": {
@@ -15,13 +15,13 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "symfony/console": "~2.8|~3.0",
-        "php-di/invoker": "~1.2",
-        "container-interop/container-interop": "~1.0"
+        "php": ">=7.0",
+        "symfony/console": "~3.0",
+        "php-di/invoker": "~2.0",
+        "psr/container": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
-        "mnapoli/phpunit-easymock": "~0.1.0"
+        "phpunit/phpunit": "~5.0",
+        "mnapoli/phpunit-easymock": "~0.2.0"
     }
 }

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -7,7 +7,7 @@ Silly helps you to do dependency injection without forcing you to use a specific
 
 ## Choose your container
 
-Silly uses the [container-interop standard](https://github.com/container-interop/container-interop) in order to be compatible with any dependency injection container. The idea is simple: you can set up Silly to use the implementation you prefer.
+Silly uses the [PSR-11 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md) in order to be compatible with any dependency injection container. The idea is simple: you can set up Silly to use the implementation you prefer.
 
 ```php
 $app->useContainer($container);

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,7 +2,7 @@
 
 namespace Silly;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Invoker\Exception\InvocationException;
 use Invoker\Invoker;
 use Invoker\InvokerInterface;
@@ -136,7 +136,7 @@ class Application extends SymfonyApplication
      * In case of conflict with a command parameters, the command parameter is injected
      * in priority over dependency injection.
      *
-     * @param ContainerInterface $container Container implementing container-interop
+     * @param ContainerInterface $container Container implementing PSR-11
      * @param bool               $injectByTypeHint
      * @param bool               $injectByParameterName
      */

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
 {
+    use EasyMock;
+
     /**
      * @var Application
      */
@@ -40,7 +42,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     public function allows_to_set_an_invoker()
     {
         /** @var InvokerInterface $invoker */
-        $invoker = EasyMock::mock(InvokerInterface::class);
+        $invoker = $this->easyMock(InvokerInterface::class);
 
         $this->application->setInvoker($invoker);
 

--- a/tests/Mock/ArrayContainer.php
+++ b/tests/Mock/ArrayContainer.php
@@ -2,7 +2,7 @@
 
 namespace Silly\Test\Mock;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class ArrayContainer implements ContainerInterface
 {


### PR DESCRIPTION
Fix #33 

- use PSR-11 instead of container-interop
- support only PHP 7 and up