### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "mnapoli/phpunit-easymock": "~0.2.0"
+        "phpunit/phpunit": "~6.4",
+        "mnapoli/phpunit-easymock": "~1.0"
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -4,11 +4,12 @@ namespace Silly\Test;
 
 use EasyMock\EasyMock;
 use Invoker\InvokerInterface;
+use PHPUnit\Framework\TestCase;
 use Silly\Application;
 use Silly\Test\Fixture\SpyOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -2,10 +2,11 @@
 
 namespace Silly\Test;
 
+use PHPUnit\Framework\TestCase;
 use Silly\Application;
 use Silly\Command\Command;
 
-class CommandTest extends \PHPUnit_Framework_TestCase
+class CommandTest extends TestCase
 {
     /**
      * @var Application

--- a/tests/Command/ExpressionParserTest.php
+++ b/tests/Command/ExpressionParserTest.php
@@ -2,11 +2,12 @@
 
 namespace Silly\Test\Command;
 
+use PHPUnit\Framework\TestCase;
 use Silly\Command\ExpressionParser;
 use Silly\Input\InputArgument;
 use Silly\Input\InputOption;
 
-class ExpressionParserTest extends \PHPUnit_Framework_TestCase
+class ExpressionParserTest extends TestCase
 {
     /**
      * @test

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -2,6 +2,7 @@
 
 namespace Silly\Test;
 
+use PHPUnit\Framework\TestCase;
 use Silly\Application;
 use Silly\Test\Fixture\SpyOutput;
 use Silly\Test\Mock\ArrayContainer;
@@ -13,7 +14,7 @@ use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface as Out;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class FunctionalTest extends \PHPUnit_Framework_TestCase
+class FunctionalTest extends TestCase
 {
     /**
      * @var Application


### PR DESCRIPTION
As we support `PHP 7`, I've upgraded our suite of tests to `PHPUnit 6`.