### PR TITLE
gitattributes: skip phpcs config from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /.coveralls.yml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.php_cs export-ignore
 /.travis.yml export-ignore
 /couscous.yml export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
I missed one file from exclusion

refs: #49