### PR TITLE
Add default value resolver to Invoker's resolver chain.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -9,6 +9,7 @@ use Invoker\InvokerInterface;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
 use Invoker\ParameterResolver\Container\ParameterNameContainerResolver;
 use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
+use Invoker\ParameterResolver\DefaultValueResolver;
 use Invoker\ParameterResolver\ResolverChain;
 use Invoker\ParameterResolver\TypeHintResolver;
 use Invoker\Reflection\CallableReflection;
@@ -299,6 +300,7 @@ class Application extends SymfonyApplication
             new AssociativeArrayResolver,
             new HyphenatedInputResolver,
             new TypeHintResolver,
+            new DefaultValueResolver,
         ]);
     }
 


### PR DESCRIPTION
Without the `DefaultValueResolver`, the `Invoker` library doesn't automatically consider the default values specified on the callable itself when resolving the callable.

The documentation already says that default values can be specified on the callable, so this simply returns the code to matching the expectations established by the existing documentation.