### PR TITLE
Using assertSame to make assertEquals strict

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -2,7 +2,6 @@
 
 namespace Silly;
 
-use Psr\Container\ContainerInterface;
 use Invoker\Exception\InvocationException;
 use Invoker\Invoker;
 use Invoker\InvokerInterface;
@@ -12,6 +11,7 @@ use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
 use Invoker\ParameterResolver\ResolverChain;
 use Invoker\ParameterResolver\TypeHintResolver;
 use Invoker\Reflection\CallableReflection;
+use Psr\Container\ContainerInterface;
 use Silly\Command\Command;
 use Silly\Command\ExpressionParser;
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -94,11 +94,7 @@ class Application extends SymfonyApplication
             try {
                 return $this->invoker->call($callable, $parameters);
             } catch (InvocationException $e) {
-                throw new \RuntimeException(sprintf(
-                    "Impossible to call the '%s' command: %s",
-                    $input->getFirstArgument(),
-                    $e->getMessage()
-                ), 0, $e);
+                throw new \RuntimeException(sprintf("Impossible to call the '%s' command: %s", $input->getFirstArgument(), $e->getMessage()), 0, $e);
             }
         };
 
@@ -200,7 +196,6 @@ class Application extends SymfonyApplication
 
     /**
      * @param string $expression
-     * @param callable $callable
      * @return Command
      */
     private function createCommand($expression, callable $callable)

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -55,9 +55,7 @@ class Command extends \Symfony\Component\Console\Command\Command
             } elseif ($definition->hasOption($name)) {
                 $input = $definition->getOption($name);
             } else {
-                throw new \InvalidArgumentException(
-                    "Unable to set default for [{$name}]. It does not exist as an argument or option."
-                );
+                throw new \InvalidArgumentException("Unable to set default for [{$name}]. It does not exist as an argument or option.");
             }
 
             $input->setDefault($default);

--- a/src/HyphenatedInputResolver.php
+++ b/src/HyphenatedInputResolver.php
@@ -2,8 +2,8 @@
 
 namespace Silly;
 
-use ReflectionFunctionAbstract;
 use Invoker\ParameterResolver\ParameterResolver;
+use ReflectionFunctionAbstract;
 
 /**
  * Tries to maps hyphenated parameters to a similarly-named,

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -62,7 +62,7 @@ class ApplicationTest extends TestCase
         $output = new SpyOutput();
         $code = $this->application->runCommand('foo', $output);
 
-        $this->assertEquals('hello', $output->output);
+        $this->assertSame('hello', $output->output);
         $this->assertSame(0, $code);
     }
 

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silly\Test;
+namespace Silly\Test\Command;
 
 use PHPUnit\Framework\TestCase;
 use Silly\Application;
@@ -40,10 +40,10 @@ class CommandTest extends TestCase
 
         $definition = $this->command->getDefinition();
 
-        $this->assertEquals('Greet someone', $this->command->getDescription());
-        $this->assertEquals('Who?', $definition->getArgument('name')->getDescription());
-        $this->assertEquals('Yell?', $definition->getOption('yell')->getDescription());
-        $this->assertEquals('# of times to greet?', $definition->getOption('times')->getDescription());
+        $this->assertSame('Greet someone', $this->command->getDescription());
+        $this->assertSame('Who?', $definition->getArgument('name')->getDescription());
+        $this->assertSame('Yell?', $definition->getOption('yell')->getDescription());
+        $this->assertSame('# of times to greet?', $definition->getOption('times')->getDescription());
     }
 
     /**
@@ -58,8 +58,8 @@ class CommandTest extends TestCase
 
         $definition = $this->command->getDefinition();
 
-        $this->assertEquals('John', $definition->getArgument('name')->getDefault());
-        $this->assertEquals('1', $definition->getOption('times')->getDefault());
+        $this->assertSame('John', $definition->getArgument('name')->getDefault());
+        $this->assertSame('1', $definition->getOption('times')->getDefault());
     }
 
     /**
@@ -73,7 +73,7 @@ class CommandTest extends TestCase
 
         $definition = $command->getDefinition();
 
-        $this->assertEquals(15, $definition->getOption("times")->getDefault());
+        $this->assertSame(15, $definition->getOption("times")->getDefault());
     }
 
     /**
@@ -87,7 +87,7 @@ class CommandTest extends TestCase
 
         $definition = $command->getDefinition();
 
-        $this->assertEquals(15, $definition->getOption("number-of-times")->getDefault());
+        $this->assertSame(15, $definition->getOption("number-of-times")->getDefault());
     }
 
     /**
@@ -99,7 +99,7 @@ class CommandTest extends TestCase
 
         $definition = $command->getDefinition();
 
-        $this->assertEquals(15, $definition->getOption("times")->getDefault());
+        $this->assertSame(15, $definition->getOption("times")->getDefault());
     }
 
     /**
@@ -113,7 +113,7 @@ class CommandTest extends TestCase
 
         $definition = $this->command->getDefinition();
 
-        $this->assertEquals(5, $definition->getOption("times")->getDefault());
+        $this->assertSame('5', $definition->getOption("times")->getDefault());
     }
 
     /**

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -48,7 +48,7 @@ class FunctionalTest extends TestCase
             return 1;
         });
         $code = $this->application->run(new StringInput('greet'), new SpyOutput());
-        $this->assertEquals(1, $code);
+        $this->assertSame(1, $code);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assert equals strict.
- Fix coding style via `php vendor/bin/php-cs-fixer fix --format=txt --verbose --diff --diff-format=udiff --allow-risky=yes --config=.php_cs` command.