### PR TITLE
Use ArrayInput instead of StringInput

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Silly\Command\Command;
 use Silly\Command\ExpressionParser;
 use Symfony\Component\Console\Application as SymfonyApplication;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
@@ -168,7 +169,7 @@ class Application extends SymfonyApplication
 
         $command = $this->find($this->getCommandName($input));
 
-        return $command->run($input, $output ?: new NullOutput());
+        return $command->run(new ArrayInput($input->getArguments()), $output ?: new NullOutput());
     }
 
     /**


### PR DESCRIPTION
Hello,

I've got this error with a command in a command : 

> Too many arguments to "xxx" command, expected arguments "yyy".

I've check the [Symfony documentation](https://symfony.com/doc/current/console/calling_commands.html) and it's better to use ArrayInput. I've made the change on my vendor and I don't have the error any more.