### PR TITLE
Add return type to suppress deprecation

### DIFF
--- a/src/HyphenatedInputResolver.php
+++ b/src/HyphenatedInputResolver.php
@@ -18,7 +18,7 @@ class HyphenatedInputResolver implements ParameterResolver
         ReflectionFunctionAbstract $reflection,
         array $providedParameters,
         array $resolvedParameters
-    ) {
+    ): array {
         $parameters = [];
 
         foreach ($reflection->getParameters() as $index => $parameter) {


### PR DESCRIPTION
When running with Symfony DebugLoader we get this message:

```
User Deprecated: Method "Invoker\ParameterResolver\ParameterResolver::getParameters()" might add "array" as a native return type declaration in the future. Do the same in implementation "Silly\HyphenatedInputResolver" now to avoid errors or add an explicit @return annotation to suppress this message.
```