### PR TITLE
Revert "Use ArrayInput instead of StringInput"

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -15,7 +15,6 @@ use Psr\Container\ContainerInterface;
 use Silly\Command\Command;
 use Silly\Command\ExpressionParser;
 use Symfony\Component\Console\Application as SymfonyApplication;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
@@ -169,7 +168,7 @@ class Application extends SymfonyApplication
 
         $command = $this->find($this->getCommandName($input));
 
-        return $command->run(new ArrayInput($input->getArguments()), $output ?: new NullOutput());
+        return $command->run($input, $output ?: new NullOutput());
     }
 
     /**

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -69,6 +69,41 @@ class ApplicationTest extends TestCase
     /**
      * @test
      */
+    public function runs_a_command_with_arguments()
+    {
+        $this->application->command('greet [name] [--yell]', function ($name, $yell, OutputInterface $output) {
+            if ($name) {
+                $text = 'Hello, '.$name;
+            } else {
+                $text = 'Hello';
+            }
+
+            if ($yell) {
+                $text = strtoupper($text);
+            }
+
+            $output->write($text);
+        });
+
+        $output = new SpyOutput();
+        $code = $this->application->runCommand('greet', $output);
+        $this->assertSame('Hello', $output->output);
+        $this->assertSame(0, $code);
+
+        $output = new SpyOutput();
+        $code = $this->application->runCommand('greet John', $output);
+        $this->assertSame('Hello, John', $output->output);
+        $this->assertSame(0, $code);
+
+        $output = new SpyOutput();
+        $code = $this->application->runCommand('greet John --yell', $output);
+        $this->assertSame('HELLO, JOHN', $output->output);
+        $this->assertSame(0, $code);
+    }
+
+    /**
+     * @test
+     */
     public function runs_a_command_without_output()
     {
         $this->application->command('foo', function (OutputInterface $output) {


### PR DESCRIPTION
This reverts commit 9210c84 (#66) to fix usage of arguments/flags/options in sub-commands.

See #69 for details.