### PR TITLE
Remove PHP 8.4 deprecation warning

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -162,7 +162,7 @@ class Application extends SymfonyApplication
      *
      * @return int 0 if everything went fine, or an error code
      */
-    public function runCommand($command, OutputInterface $output = null)
+    public function runCommand($command, ?OutputInterface $output = null)
     {
         $input = new StringInput($command);
 


### PR DESCRIPTION
This PR fixes the deprecation warning that's showing up with PHP 8.4:

`Deprecated: Silly\Application::runCommand(): Implicitly marking parameter $output as nullable is deprecated, the explicit nullable type must be used instead in silly/src/Application.php on line 165`