### PR TITLE
Remove Jigsaw from example applications in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Interested in seeing examples of Silly applications? Have a look at this short s
 - [Laravel Valet](https://github.com/laravel/valet/blob/7ed0280374340b30f1e2698fe85d7db543570f57/cli/valet.php)
 - [Blacksmith](https://github.com/mpociot/blacksmith/blob/320e97b9677f9e885d1f478593143f329afb9510/blacksmith)
 - [Documentarian](https://github.com/mpociot/documentarian/blob/34189ff3357aa3b013930b471410f135f09792de/documentarian)
-- [Jigsaw](https://github.com/tightenco/jigsaw/blob/9d50dcf65187cc0b834f194a15e4e90c6d68b9fc/jigsaw)
 
 ## Contributing
 


### PR DESCRIPTION
[Jigsaw](https://github.com/tighten/jigsaw) does not use Silly. They removed it in https://github.com/tighten/jigsaw/commit/9064da7ea77bf6b41ee24696e0515275ef83c18a